### PR TITLE
fixing the jsx-a11y/href-no-hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
     "deploy": "gh-pages -d build"
   },
   "devDependencies": {
-    "eslint-config-airbnb": "^16.1.0",
-    "eslint-plugin-import": "^2.8.0",
-    "eslint-plugin-jsx-a11y": "^6.0.2",
-    "eslint-plugin-react": "^7.5.1"
+    "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.1",
+    "eslint-loader": "^1.8.0",
+    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-react": "^7.1.0"
   }
 }


### PR DESCRIPTION
"warning  Definition for rule 'jsx-a11y/href-no-hash' was not found  jsx-a11y/href-no-hash"